### PR TITLE
Stop overwriting the extension data from container.js.

### DIFF
--- a/src/tasks/helpers/getEdgeContainer.js
+++ b/src/tasks/helpers/getEdgeContainer.js
@@ -147,7 +147,8 @@ module.exports = () => {
   }
 
   const extensionsOutput = {
-    sandbox: { displayName: 'Sandbox' }
+    sandbox: { displayName: 'Sandbox' },
+    ...container.extensions
   };
   const modulesOutput = {};
   container.extensions = extensionsOutput;


### PR DESCRIPTION
## Description

Make extension settings available inside the Library Sandbox for an Edge extension.

## Motivation and Context

The extension settings for an edge extension were not available inside the Library Sandbox. This was happening because the extensions meta data from `container.js` were overwritten with a new object.

## How Has This Been Tested?

Tested inside the Google Edge extension.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
