### PR TITLE
PDCL-5745: fix duplicate extension modules

### DIFF
--- a/src/app/components/ModalDataElementSelector.js
+++ b/src/app/components/ModalDataElementSelector.js
@@ -54,7 +54,7 @@ export default ({ dataElements, platform, tokenize, onClose, onSave }) => {
   return (
     <DialogContainer>
       <Dialog>
-        <Heading>Datas Element Selector</Heading>
+        <Heading>Data Element Selector</Heading>
         <Divider />
         <Content>
           <Picker

--- a/src/app/components/ModalDataElementSelector.js
+++ b/src/app/components/ModalDataElementSelector.js
@@ -24,7 +24,7 @@ import {
   Item
 } from '@adobe/react-spectrum';
 
-const handleOnSave = ({ dataElement, tokenize, platform, onSave }) => {
+const handleOnSave = ({ dataElement, tokenize = true, platform, onSave }) => {
   let newDataElement = '';
 
   if (dataElement) {

--- a/src/tasks/helpers/extensionDescriptorPaths.js
+++ b/src/tasks/helpers/extensionDescriptorPaths.js
@@ -33,7 +33,7 @@ if (isSandboxLinked()) {
   );
 }
 
-function getExtensionPlatform(filePath) {
+const getExtensionPlatform = (filePath) => {
   const fileContents = JSON.parse(fs.readFileSync(path.resolve(filePath)));
   if (!fileContents.platform) {
     throw new Error(
@@ -42,7 +42,7 @@ function getExtensionPlatform(filePath) {
     );
   }
   return fileContents.platform;
-}
+};
 
 // if there's only 1 path, skip over this logic
 if (extensionJsonPaths.length > 1) {
@@ -63,7 +63,8 @@ if (extensionJsonPaths.length > 1) {
     return 0;
   });
 
-  const extensionPlatform = getExtensionPlatform(extensionJsonPaths[extensionJsonPaths.length - 1]);
+  const topExtensionPathIndex = extensionJsonPaths.indexOf(EXTENSION_DESCRIPTOR_FILENAME);
+  const extensionPlatform = getExtensionPlatform(extensionJsonPaths[topExtensionPathIndex]);
 
   // Remove duplicate paths and paths that aren't of the same platform as the extension
   // that's launching the sandbox¸

--- a/src/tasks/helpers/saveContainer.js
+++ b/src/tasks/helpers/saveContainer.js
@@ -238,7 +238,7 @@ const getTransformsData = (type, delegateConfig) => {
     const modulePath = modulePathParts.join('/');
 
     if (extensionName === 'sandbox') {
-      if (delegateConfig.modulePath === 'sandbox/customCode.js') {
+      if (descriptor.platform === 'edge' && delegateConfig.modulePath === 'sandbox/customCode.js') {
         return [
           {
             type: 'function',

--- a/src/tasks/run.js
+++ b/src/tasks/run.js
@@ -185,6 +185,9 @@ const configureApp = (app) => {
   // javascriptVariable.html (javascript variable data element).
   app.use(express.static(files.SANDBOX_EXTENSION_SRC_PATH));
 
+  // Serve files written by custom code actions
+  app.use('/files', express.static(path.resolve(files.CONSUMER_PROVIDED_FILES_PATH, 'files')));
+
   app.get('/editor-container.js', (req, res) => {
     let containerText;
 
@@ -233,7 +236,7 @@ const configureApp = (app) => {
     } catch (error) {
       console.log(error);
       res.status(500);
-      res.send(error.messa);
+      res.send(error.message);
     }
   });
 


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

PDCL-5745: filter out loading descriptors nested within dependencies if they don't
match the platform of the main `extension.json` at the root project.

## Description

When duplicate module paths are pulled in during descriptor resolution, it's possible that we're loading code for the
wrong platform. This manifested by observing trying to test the `core-extension` but the `core-extension-edge` modules were used instead since they're a dependency of the sandbox tool.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-5745

## Motivation and Context

Could not accurately test the core extension in sandbox anymore. It also seemed like it could be a bigger problem as the same extensions are made for both client and server side.

## How Has This Been Tested?

manual verification

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
