### PR TITLE
Resolution for Issue 62

### DIFF
--- a/src/tasks/init.js
+++ b/src/tasks/init.js
@@ -18,7 +18,7 @@ governing permissions and limitations under the License.
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 
-const PLATFORMS = require('../helpers/sharedConstants');
+const PLATFORMS = require('../helpers/sharedConstants').PLATFORMS;
 const fs = require('fs-extra');
 const path = require('path');
 const files = require('./constants/files');

--- a/src/tasks/init.js
+++ b/src/tasks/init.js
@@ -18,8 +18,7 @@ governing permissions and limitations under the License.
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 
-import { PLATFORMS } from '../helpers/sharedConstants';
-
+const PLATFORMS = require('../helpers/sharedConstants');
 const fs = require('fs-extra');
 const path = require('path');
 const files = require('./constants/files');


### PR DESCRIPTION
<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

This is the proposed resolution for Issue #62 

## Related Issue

https://github.com/adobe/reactor-sandbox/issues/62

## Motivation and Context

The import statement introduced in 11.1.6 within https://github.com/adobe/reactor-sandbox/blob/master/src/tasks/init.js

`import { PLATFORMS } from '../helpers/sharedConstants';`

caused the sandbox to fail when invoked within a node script. 

## How Has This Been Tested?

Tested in my local environment

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
