### PR TITLE
PDCL-6109: Update import of PLATFORMS in init.js

### DIFF
--- a/src/tasks/init.js
+++ b/src/tasks/init.js
@@ -18,11 +18,10 @@ governing permissions and limitations under the License.
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 
-import { PLATFORMS } from '../helpers/sharedConstants';
-
 const fs = require('fs-extra');
 const path = require('path');
 const files = require('./constants/files');
+const { PLATFORMS } = require('../helpers/sharedConstants');
 
 module.exports = () => {
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
to support running as a node shell script.

<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

Resolves #62 

## Description

Addresses an issue where the sandbox would no longer run inside of a node shell script.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6109

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

1. Ran the sandbox using the core extension
2. 
`#!/usr/bin/env node`
`const sandbox = require('@adobe/reactor-sandbox');`
`sandbox.run();`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
