### PR TITLE
PDCL-6132 Add support for property ID inside the sandbox.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "11.1.7",
+  "version": "11.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "11.1.7",
+  "version": "11.2.0",
   "description": "Tasks for creating a sandbox for manually testing Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/src/app/libraryEditor/components/ComponentIframe.js
+++ b/src/app/libraryEditor/components/ComponentIframe.js
@@ -56,7 +56,7 @@ const renderIframe = ({
   const extensionInitOptions = {
     settings,
     company: companySettings,
-    propertySettings,
+    propertySettings: propertySettings.settings,
     tokens: otherSettings.tokens
   };
 

--- a/src/app/libraryEditor/components/OtherSettings.js
+++ b/src/app/libraryEditor/components/OtherSettings.js
@@ -10,15 +10,13 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import produce from 'immer';
 import { useDispatch, useSelector } from 'react-redux';
 import { View, Heading, Divider, TextField, Button, Flex } from '@adobe/react-spectrum';
 import { useHistory } from 'react-router-dom';
 import { NAMED_ROUTES } from '../../constants';
-import { PLATFORMS } from '../../../helpers/sharedConstants';
 import ErrorMessage from '../../components/ErrorMessage';
-import ExtensionDescriptorContext from '../../extensionDescriptorContext';
 
 const handleOrgIdChange = ({ orgId, setCompanySettings, companySettings }) => {
   setCompanySettings(
@@ -36,10 +34,10 @@ const handleImsChange = ({ imsAccess, otherSettings, setOtherSettings }) => {
   );
 };
 
-const isValid = ({ companySettings, otherSettings, setErrors, platform }) => {
+const isValid = ({ companySettings, otherSettings, setErrors }) => {
   const errors = {};
 
-  if (!companySettings.orgId && platform !== PLATFORMS.EDGE) {
+  if (!companySettings.orgId) {
     errors.orgId = true;
   }
 
@@ -52,7 +50,6 @@ const isValid = ({ companySettings, otherSettings, setErrors, platform }) => {
 };
 
 const handleSave = async ({
-  platform,
   companySettings,
   otherSettings,
   setErrors,
@@ -60,7 +57,7 @@ const handleSave = async ({
   saveCompanySettings,
   saveOtherSettings
 }) => {
-  if (!isValid({ companySettings, otherSettings, setErrors, platform })) {
+  if (!isValid({ companySettings, otherSettings, setErrors })) {
     return false;
   }
 
@@ -82,7 +79,6 @@ export default () => {
 
   const [companySettings, setCompanySettings] = useState(useSelector((state) => state.company));
   const [otherSettings, setOtherSettings] = useState(useSelector((state) => state.otherSettings));
-  const { platform } = useContext(ExtensionDescriptorContext);
 
   return errors.api ? (
     <View flex>
@@ -91,26 +87,23 @@ export default () => {
   ) : (
     <Flex direction="column">
       <View width="100%" alignSelf="center">
-        {platform !== PLATFORMS.EDGE && (
-          <>
-            <Heading level={2}>Company Settings</Heading>
-            <Divider />
-            <Flex direction="column" alignItems="center">
-              <TextField
-                label="Organization ID"
-                necessityIndicator="label"
-                isRequired
-                width="size-6000"
-                marginTop="size-150"
-                validationState={errors.orgId ? 'invalid' : ''}
-                value={companySettings.orgId || ''}
-                onChange={(orgId) => {
-                  handleOrgIdChange({ orgId, companySettings, setCompanySettings });
-                }}
-              />
-            </Flex>
-          </>
-        )}
+        <Heading level={2}>Company Settings</Heading>
+        <Divider />
+        <Flex direction="column" alignItems="center">
+          <TextField
+            label="Organization ID"
+            necessityIndicator="label"
+            isRequired
+            width="size-6000"
+            marginTop="size-150"
+            validationState={errors.orgId ? 'invalid' : ''}
+            value={companySettings.orgId || ''}
+            onChange={(orgId) => {
+              handleOrgIdChange({ orgId, companySettings, setCompanySettings });
+            }}
+          />
+        </Flex>
+
         <Heading level={2} marginTop="size-400">
           IMS Token Settings
         </Heading>
@@ -136,7 +129,6 @@ export default () => {
               marginTop="size-400"
               onPress={() => {
                 handleSave({
-                  platform,
                   companySettings,
                   otherSettings,
                   setErrors,

--- a/src/app/libraryEditor/components/PropertySettings.js
+++ b/src/app/libraryEditor/components/PropertySettings.js
@@ -22,11 +22,15 @@ import { PLATFORMS } from '../../../helpers/sharedConstants';
 import ErrorMessage from '../../components/ErrorMessage';
 import ExtensionDescriptorContext from '../../extensionDescriptorContext';
 
-const isValid = ({ domains, setErrors }) => {
+const isValid = ({ domains, propertyId, setErrors }) => {
   const errors = {};
 
   if (!domains) {
     errors.domains = true;
+  }
+
+  if (!propertyId) {
+    errors.propertyId = true;
   }
 
   setErrors(errors);
@@ -35,12 +39,13 @@ const isValid = ({ domains, setErrors }) => {
 
 const handleSave = async ({
   domains,
+  propertyId,
   setErrors,
   history,
   propertySettings,
   savePropertySettings
 }) => {
-  if (!isValid({ domains, setErrors })) {
+  if (!isValid({ domains, propertyId, setErrors })) {
     return false;
   }
 
@@ -48,6 +53,7 @@ const handleSave = async ({
     await savePropertySettings(
       produce(propertySettings, (draft) => {
         draft.settings.domains = domains.split(',').map((s) => s.trim());
+        draft.settings.id = propertyId;
       })
     );
     history.push(NAMED_ROUTES.LIBRARY_EDITOR);
@@ -65,6 +71,7 @@ export default () => {
   const propertySettings = useSelector((state) => state.property);
   const [errors, setErrors] = useState({});
   const [domains, setDomains] = useState((propertySettings.settings.domains || []).join(', '));
+  const [propertyId, setPropertyId] = useState(propertySettings.settings.id);
   const { platform } = useContext(ExtensionDescriptorContext);
 
   return errors.api ? (
@@ -74,13 +81,23 @@ export default () => {
   ) : (
     <View padding="size-200" flex>
       <View margin="2rem auto" maxWidth="50rem">
-        <Heading level={2}>Property Settings</Heading>
+        <Heading level={2}>Propertys Settings</Heading>
         <Divider />
-        {platform === PLATFORMS.EDGE ? (
-          <View padding="size-250">At this moment, there are no settings to configure.</View>
-        ) : (
-          <Flex direction="column" alignItems="center">
-            <View>
+
+        <Flex direction="column" alignItems="center">
+          <TextField
+            label="Property ID"
+            necessityIndicator="label"
+            isRequired
+            width="size-6000"
+            marginTop="size-150"
+            validationState={errors.propertyId ? 'invalid' : ''}
+            value={propertyId}
+            onChange={setPropertyId}
+          />
+
+          {platform !== PLATFORMS.EDGE && (
+            <>
               <TextField
                 label="Domains List"
                 necessityIndicator="label"
@@ -91,27 +108,31 @@ export default () => {
                 value={domains}
                 onChange={setDomains}
               />
-              <Heading level={6} margin="size-100">
+
+              <Heading level={6} margin="size-100" width="size-6000">
                 Comma separated values are accepted.
               </Heading>
-              <Button
-                variant="cta"
-                marginTop="size-100"
-                onPress={() => {
-                  handleSave({
-                    domains,
-                    setErrors,
-                    history,
-                    propertySettings,
-                    savePropertySettings: dispatch.property.savePropertySettings
-                  });
-                }}
-              >
-                Save
-              </Button>
-            </View>
-          </Flex>
-        )}
+            </>
+          )}
+
+          <View marginTop="size-400" alignItems="left" width="size-6000">
+            <Button
+              variant="cta"
+              onPress={() => {
+                handleSave({
+                  domains,
+                  propertyId,
+                  setErrors,
+                  history,
+                  propertySettings,
+                  savePropertySettings: dispatch.property.savePropertySettings
+                });
+              }}
+            >
+              Save
+            </Button>
+          </View>
+        </Flex>
       </View>
     </View>
   );

--- a/src/app/libraryEditor/models/brain.js
+++ b/src/app/libraryEditor/models/brain.js
@@ -114,20 +114,16 @@ export default {
         property: {
           settings:
             platform === PLATFORMS.EDGE
-              ? {}
+              ? { id: 'PR12345' }
               : {
+                  id: 'PR12345',
                   domains: ['example.com'],
-                  linkDelay: 100,
-                  trackingCookieName: 'sat_track',
                   undefinedVarsReturnEmpty: false
                 }
         },
-        company:
-          platform === PLATFORMS.EDGE
-            ? {}
-            : {
-                orgId: 'ABCDEFGHIJKLMNOPQRSTUVWX@AdobeOrg'
-              }
+        company: {
+          orgId: 'ABCDEFGHIJKLMNOPQRSTUVWX@AdobeOrg'
+        }
       };
 
       await this.pushDataDown(emptyContainerData);

--- a/src/app/libraryEditor/models/property.js
+++ b/src/app/libraryEditor/models/property.js
@@ -27,8 +27,6 @@ export default {
   effects: {
     async savePropertySettings(payload, rootState) {
       const propertySettings = produce(payload, (draft) => {
-        draft.settings.linkDelay = 100;
-        draft.settings.trackingCookieName = 'sat_track';
         draft.settings.undefinedVarsReturnEmpty = false;
       });
 

--- a/src/app/viewSandbox/components/helpers/getDefaultInitInfo.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultInitInfo.js
@@ -16,9 +16,8 @@ export default ({ type, descriptor }) => {
   const info = {
     settings: null,
     propertySettings: {
+      id: 'PR12345',
       domains: ['adobe.com', 'example.com'],
-      linkDelay: 100,
-      trackingCookieName: 'sat_track',
       undefinedVarsReturnEmpty: false
     },
     tokens: {

--- a/src/client/initFiles/container.js
+++ b/src/client/initFiles/container.js
@@ -62,9 +62,8 @@ module.exports = {
   property: {
     name: 'Sandbox property',
     settings: {
+      id: 'PR12345',
       domains: ['adobe.com', 'example.com'],
-      linkDelay: 100,
-      trackingCookieName: 'sat_track',
       undefinedVarsReturnEmpty: false
     }
   },


### PR DESCRIPTION
## Description

For the edge extension, we need the property ID to be sent to the views in order to be able to hit the correct Launch API endpoint.

## Related Issue
https://jira.corp.adobe.com/browse/PDCL-6132

## Motivation and Context

The property ID is already sent by the Lens but wasn't supported by the sandbox. At the same time I enabled the Org ID field inside the sandbox for edge extensions since this is also required for hitting the Launch API endpoint.

## How Has This Been Tested?

Tested the changes while I was developing the LSS extension.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
