### PR TITLE
Change the way we detect if we are doing dev work on sandbox.

### DIFF
--- a/src/helpers/isSandboxLinked.js
+++ b/src/helpers/isSandboxLinked.js
@@ -14,8 +14,10 @@ const fs = require('fs');
 
 module.exports = () => {
   try {
-    const stat = fs.lstatSync('node_modules/@adobe/reactor-sandbox');
-    return stat.isSymbolicLink();
+    // We no longer test for a symbolic link because of pnpm.
+    // Probably the safest way to detect if we are doing developer
+    // work on sandbox is to search for the Git directory.
+    return fs.existsSync('node_modules/@adobe/reactor-sandbox/.git');
   } catch (e) {
     return false;
   }


### PR DESCRIPTION
## Description

Running the sandbox inside a project that was installed using `pnpm` was not possible.

## Motivation and Context

`pnpm` symlinks all the dependencies that are installed inside the `node_modules` folder. If someone wants to use `pnpm` inside his extension, `sandobx` will not start. I decided to change the way we detect if we are doing developer work inside sandbox.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
