### PR TITLE
Add platform to the local storage keys.

### DIFF
--- a/src/app/libraryEditor/models/brain.js
+++ b/src/app/libraryEditor/models/brain.js
@@ -23,8 +23,8 @@ import { PLATFORMS } from '../../../helpers/sharedConstants';
 // eslint-disable-next-line import/no-cycle
 import { dispatch } from '../../store';
 
-const loadOtherSettings = (extensionName) => {
-  localStorage.loadStateFor(extensionName);
+const loadOtherSettings = (platform, extensionName) => {
+  localStorage.loadStateFor(platform, extensionName);
 
   if (!localStorage.get('otherSettings')) {
     localStorage.update('otherSettings', {
@@ -73,7 +73,7 @@ export default {
       this.setPlatform(platform);
 
       Promise.all([
-        this.loadRegistryData(),
+        this.loadRegistryData(platform),
         this.loadContainerData().catch(() => {
           this.clearContainerData();
         })
@@ -84,7 +84,7 @@ export default {
         .catch((e) => this.setError(e));
     },
 
-    async loadRegistryData() {
+    async loadRegistryData(platform) {
       const data = await getEditorRegistry();
 
       dispatch.registry.setRegistry(
@@ -94,7 +94,7 @@ export default {
       );
 
       this.setExtensionName(data.currentExtensionName);
-      loadOtherSettings(data.currentExtensionName);
+      loadOtherSettings(platform, data.currentExtensionName);
     },
 
     async loadContainerData() {

--- a/src/app/libraryEditor/models/localStorage.js
+++ b/src/app/libraryEditor/models/localStorage.js
@@ -14,6 +14,7 @@ import produce from 'immer';
 
 export default {
   extensionName: null,
+  platform: null,
   state: {},
   get(key) {
     return this.state[key];
@@ -21,16 +22,18 @@ export default {
   save() {
     if (this.extensionName) {
       localStorage.setItem(
-        `sandbox-rule-editor-container-${this.extensionName}`,
+        `sandboxRuleEditorContainer/${this.platform}/${this.extensionName}`,
         JSON.stringify(this.state)
       );
     }
   },
-  loadStateFor(extensionName) {
+  loadStateFor(platform, extensionName) {
     this.extensionName = extensionName;
+    this.platform = platform;
 
     const state =
-      JSON.parse(localStorage.getItem(`sandbox-rule-editor-container-${extensionName}`)) || {};
+      JSON.parse(localStorage.getItem(`sandboxRuleEditorContainer/${platform}/${extensionName}`)) ||
+      {};
 
     if (state) {
       this.state = state;
@@ -44,6 +47,6 @@ export default {
   },
 
   delete() {
-    localStorage.removeItem(`sandbox-rule-editor-container-${this.extensionName}`);
+    localStorage.removeItem(`sandboxRuleEditorContainer/${this.platform}/${this.extensionName}`);
   }
 };

--- a/src/app/viewSandbox/components/ViewsSelector.jsx
+++ b/src/app/viewSandbox/components/ViewsSelector.jsx
@@ -18,12 +18,17 @@ import buildViewOptions from './helpers/buildViewOptions';
 import detectViewTypeAndViewValues from './helpers/detectViewTypeAndViewValues';
 import updateSelectedDescriptor from './helpers/updateSelectedDescriptor';
 import VIEW_GROUPS from '../helpers/viewsGroups';
+import { PLATFORMS } from '../../../helpers/sharedConstants';
 
-const saveLastSelectedViewType = (extensionName, viewType) =>
-  localStorage.setItem(`lastSelectedViewType/${extensionName}`, viewType);
+const saveLastSelectedViewType = (platform, extensionName, viewType) => {
+  platform = platform || PLATFORMS.WEB;
+  localStorage.setItem(`lastSelectedViewType/${platform}/${extensionName}`, viewType);
+};
 
-const saveLastSelectedView = (extensionName, view) =>
-  localStorage.setItem(`lastSelectedView/${extensionName}`, view);
+const saveLastSelectedView = (platform, extensionName, view) => {
+  platform = platform || PLATFORMS.WEB;
+  return localStorage.setItem(`lastSelectedView/${platform}/${extensionName}`, view);
+};
 
 export default ({
   state: { extensionDescriptor, extensionViewDescriptorsByValue },
@@ -65,12 +70,12 @@ export default ({
         items={buildViewTypeOptions(extensionDescriptor)}
         onSelectionChange={(k) => {
           setSelectedViewType(k);
-          saveLastSelectedViewType(extensionDescriptor?.name, k);
+          saveLastSelectedViewType(extensionDescriptor?.platform, extensionDescriptor?.name, k);
 
           // We reset the view data, so that the first view of the
           // current type will be selected from the list.
           setSelectedView('');
-          saveLastSelectedView(extensionDescriptor?.name, '');
+          saveLastSelectedView(extensionDescriptor?.platform, extensionDescriptor?.name, '');
         }}
       >
         {(item) => <Item>{item.name}</Item>}
@@ -83,7 +88,7 @@ export default ({
           items={buildViewOptions(extensionDescriptor, selectedViewType)}
           onSelectionChange={(k) => {
             setSelectedView(k);
-            saveLastSelectedView(extensionDescriptor?.name, k);
+            saveLastSelectedView(extensionDescriptor?.platform, extensionDescriptor?.name, k);
           }}
         >
           {(item) =>

--- a/src/app/viewSandbox/components/ViewsSelector.jsx
+++ b/src/app/viewSandbox/components/ViewsSelector.jsx
@@ -18,17 +18,12 @@ import buildViewOptions from './helpers/buildViewOptions';
 import detectViewTypeAndViewValues from './helpers/detectViewTypeAndViewValues';
 import updateSelectedDescriptor from './helpers/updateSelectedDescriptor';
 import VIEW_GROUPS from '../helpers/viewsGroups';
-import { PLATFORMS } from '../../../helpers/sharedConstants';
 
-const saveLastSelectedViewType = (platform, extensionName, viewType) => {
-  platform = platform || PLATFORMS.WEB;
+const saveLastSelectedViewType = (platform, extensionName, viewType) =>
   localStorage.setItem(`lastSelectedViewType/${platform}/${extensionName}`, viewType);
-};
 
-const saveLastSelectedView = (platform, extensionName, view) => {
-  platform = platform || PLATFORMS.WEB;
-  return localStorage.setItem(`lastSelectedView/${platform}/${extensionName}`, view);
-};
+const saveLastSelectedView = (platform, extensionName, view) =>
+  localStorage.setItem(`lastSelectedView/${platform}/${extensionName}`, view);
 
 export default ({
   state: { extensionDescriptor, extensionViewDescriptorsByValue },

--- a/src/app/viewSandbox/components/helpers/detectViewTypeAndViewValues.js
+++ b/src/app/viewSandbox/components/helpers/detectViewTypeAndViewValues.js
@@ -22,6 +22,7 @@ export default ({
   setSelectedView
 }) => {
   const defaultViewType = getDefaultViewType(
+    extensionDescriptor?.platform,
     extensionDescriptor?.name,
     extensionViewDescriptorsByValue
   );
@@ -30,6 +31,7 @@ export default ({
   }
 
   const defaultView = getDefaultView(
+    extensionDescriptor?.platform,
     extensionDescriptor?.name,
     selectedViewType,
     selectedViewType ? extensionDescriptor[selectedViewType] : null

--- a/src/app/viewSandbox/components/helpers/extensionViewInit.js
+++ b/src/app/viewSandbox/components/helpers/extensionViewInit.js
@@ -15,14 +15,13 @@ import { ERR_CONNECTION_DESTROYED } from 'penpal';
 import reportFatalError from './reportFatalError';
 import VIEW_GROUPS from '../../helpers/viewsGroups';
 import { LOG_PREFIX } from './constants';
-import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
 export default ({ extensionBridge, selectedDescriptor, extensionDescriptor, content }) => {
   if (!extensionBridge || !selectedDescriptor || !extensionDescriptor) {
     return;
   }
 
-  const { name: extensionName, platform = PLATFORMS.WEB } = extensionDescriptor;
+  const { name: extensionName, platform } = extensionDescriptor;
   const {
     type: delegateType,
     descriptor: { name: delegateName }

--- a/src/app/viewSandbox/components/helpers/extensionViewInit.js
+++ b/src/app/viewSandbox/components/helpers/extensionViewInit.js
@@ -15,13 +15,14 @@ import { ERR_CONNECTION_DESTROYED } from 'penpal';
 import reportFatalError from './reportFatalError';
 import VIEW_GROUPS from '../../helpers/viewsGroups';
 import { LOG_PREFIX } from './constants';
+import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
 export default ({ extensionBridge, selectedDescriptor, extensionDescriptor, content }) => {
   if (!extensionBridge || !selectedDescriptor || !extensionDescriptor) {
     return;
   }
 
-  const { name: extensionName } = extensionDescriptor;
+  const { name: extensionName, platform = PLATFORMS.WEB } = extensionDescriptor;
   const {
     type: delegateType,
     descriptor: { name: delegateName }
@@ -36,7 +37,7 @@ export default ({ extensionBridge, selectedDescriptor, extensionDescriptor, cont
           .init(parsedContent)
           .then(() => {
             localStorage.setItem(
-              `initInfo/${extensionName}/${delegateType}${
+              `initInfo/${platform}/${extensionName}/${delegateType}${
                 delegateType !== VIEW_GROUPS.CONFIGURATION ? `/${delegateName}` : ''
               }`,
               content

--- a/src/app/viewSandbox/components/helpers/getDefaultView.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultView.js
@@ -13,13 +13,15 @@ governing permissions and limitations under the License.
 import VIEW_GROUPS from '../../helpers/viewsGroups';
 import getCategorizedItems from './getCategorizedItems';
 import getSortedCategories from './getSortedCategories';
+import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
-export default (extensionName, viewType, viewDescriptorsByType) => {
+export default (platform, extensionName, viewType, viewDescriptorsByType) => {
+  platform = platform || PLATFORMS.WEB;
   if (viewType === VIEW_GROUPS.CONFIGURATION) {
     return null;
   }
 
-  const defaultView = localStorage.getItem(`lastSelectedView/${extensionName}`);
+  const defaultView = localStorage.getItem(`lastSelectedView/${platform}/${extensionName}`);
 
   if (
     viewDescriptorsByType &&

--- a/src/app/viewSandbox/components/helpers/getDefaultView.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultView.js
@@ -13,10 +13,8 @@ governing permissions and limitations under the License.
 import VIEW_GROUPS from '../../helpers/viewsGroups';
 import getCategorizedItems from './getCategorizedItems';
 import getSortedCategories from './getSortedCategories';
-import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
 export default (platform, extensionName, viewType, viewDescriptorsByType) => {
-  platform = platform || PLATFORMS.WEB;
   if (viewType === VIEW_GROUPS.CONFIGURATION) {
     return null;
   }

--- a/src/app/viewSandbox/components/helpers/getDefaultViewType.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultViewType.js
@@ -10,11 +10,7 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-import { PLATFORMS } from '../../../../helpers/sharedConstants';
-
 export default (platform, extensionName, extensionViewDescriptorsByValue) => {
-  platform = platform || PLATFORMS.WEB;
-
   const defaultViewType = localStorage.getItem(`lastSelectedViewType/${platform}/${extensionName}`);
   const availableTypes = Object.keys(extensionViewDescriptorsByValue || {})
     .map((delegateName) => delegateName.split('/')[0])

--- a/src/app/viewSandbox/components/helpers/getDefaultViewType.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultViewType.js
@@ -10,8 +10,12 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
-export default (extensionName, extensionViewDescriptorsByValue) => {
-  const defaultViewType = localStorage.getItem(`lastSelectedViewType/${extensionName}`);
+import { PLATFORMS } from '../../../../helpers/sharedConstants';
+
+export default (platform, extensionName, extensionViewDescriptorsByValue) => {
+  platform = platform || PLATFORMS.WEB;
+
+  const defaultViewType = localStorage.getItem(`lastSelectedViewType/${platform}/${extensionName}`);
   const availableTypes = Object.keys(extensionViewDescriptorsByValue || {})
     .map((delegateName) => delegateName.split('/')[0])
     .filter((value, index, self) => self.indexOf(value) === index);

--- a/src/app/viewSandbox/components/helpers/getInitContent.js
+++ b/src/app/viewSandbox/components/helpers/getInitContent.js
@@ -12,7 +12,6 @@ governing permissions and limitations under the License.
 
 import getDefaultInitInfo from './getDefaultInitInfo';
 import VIEW_GROUPS from '../../helpers/viewsGroups';
-import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
 export default ({ selectedDescriptor, extensionDescriptor }) => {
   if (!extensionDescriptor || !selectedDescriptor.descriptor) {
@@ -22,7 +21,7 @@ export default ({ selectedDescriptor, extensionDescriptor }) => {
   const { type, descriptor } = selectedDescriptor;
 
   const cachedInitInfo = localStorage.getItem(
-    `initInfo/${extensionDescriptor.platform || PLATFORMS.WEB}/${extensionDescriptor.name}/${type}${
+    `initInfo/${extensionDescriptor.platform}/${extensionDescriptor.name}/${type}${
       type !== VIEW_GROUPS.CONFIGURATION ? `/${descriptor.name}` : ''
     }`
   );

--- a/src/app/viewSandbox/components/helpers/getInitContent.js
+++ b/src/app/viewSandbox/components/helpers/getInitContent.js
@@ -12,6 +12,7 @@ governing permissions and limitations under the License.
 
 import getDefaultInitInfo from './getDefaultInitInfo';
 import VIEW_GROUPS from '../../helpers/viewsGroups';
+import { PLATFORMS } from '../../../../helpers/sharedConstants';
 
 export default ({ selectedDescriptor, extensionDescriptor }) => {
   if (!extensionDescriptor || !selectedDescriptor.descriptor) {
@@ -21,7 +22,7 @@ export default ({ selectedDescriptor, extensionDescriptor }) => {
   const { type, descriptor } = selectedDescriptor;
 
   const cachedInitInfo = localStorage.getItem(
-    `initInfo/${extensionDescriptor.name}/${type}${
+    `initInfo/${extensionDescriptor.platform || PLATFORMS.WEB}/${extensionDescriptor.name}/${type}${
       type !== VIEW_GROUPS.CONFIGURATION ? `/${descriptor.name}` : ''
     }`
   );


### PR DESCRIPTION
## Description

Add the platform to the local storage keys used by sandbox.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

There is a change that settings loaded from local storage will collide if platform is not present.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
