### PR TITLE
Send API Endpoints information to extension views.

### DIFF
--- a/src/app/libraryEditor/components/ComponentIframe.js
+++ b/src/app/libraryEditor/components/ComponentIframe.js
@@ -57,7 +57,8 @@ const renderIframe = ({
     settings,
     company: companySettings,
     propertySettings: propertySettings.settings,
-    tokens: otherSettings.tokens
+    tokens: otherSettings.tokens,
+    apiEndpoints: otherSettings.apiEndpoints
   };
 
   if (extensionConfiguration) {

--- a/src/app/libraryEditor/components/OtherSettings.js
+++ b/src/app/libraryEditor/components/OtherSettings.js
@@ -34,6 +34,18 @@ const handleImsChange = ({ imsAccess, otherSettings, setOtherSettings }) => {
   );
 };
 
+const handleReactorApiEndpointChange = ({
+  reactorApiEndpoint,
+  otherSettings,
+  setOtherSettings
+}) => {
+  setOtherSettings(
+    produce(otherSettings, (draft) => {
+      draft.apiEndpoints.reactor = reactorApiEndpoint;
+    })
+  );
+};
+
 const isValid = ({ companySettings, otherSettings, setErrors }) => {
   const errors = {};
 
@@ -43,6 +55,10 @@ const isValid = ({ companySettings, otherSettings, setErrors }) => {
 
   if (!otherSettings.tokens?.imsAccess) {
     errors.imsAccess = true;
+  }
+
+  if (!otherSettings.apiEndpoints?.reactor) {
+    errors.reactorApiEndpoint = true;
   }
 
   setErrors(errors);
@@ -122,8 +138,32 @@ export default () => {
                 handleImsChange({ imsAccess, otherSettings, setOtherSettings });
               }}
             />
-            <br />
+          </View>
+        </Flex>
 
+        <Heading level={2} marginTop="size-400">
+          API Endpoints
+        </Heading>
+        <Divider />
+        <Flex direction="column" alignItems="center">
+          <View>
+            <TextField
+              label="Reactor API Endpoint"
+              necessityIndicator="label"
+              isRequired
+              width="size-6000"
+              marginTop="size-150"
+              validationState={errors.reactorApiEndpoint ? 'invalid' : ''}
+              value={otherSettings?.apiEndpoints?.reactor || ''}
+              onChange={(reactorApiEndpoint) => {
+                handleReactorApiEndpointChange({
+                  reactorApiEndpoint,
+                  otherSettings,
+                  setOtherSettings
+                });
+              }}
+            />
+            <br />
             <Button
               variant="cta"
               marginTop="size-400"

--- a/src/app/libraryEditor/models/brain.js
+++ b/src/app/libraryEditor/models/brain.js
@@ -30,6 +30,9 @@ const loadOtherSettings = (platform, extensionName) => {
     localStorage.update('otherSettings', {
       tokens: {
         imsAccess: 'fake-ims-access-token'
+      },
+      apiEndpoints: {
+        reactor: '//localhost'
       }
     });
   }

--- a/src/app/viewSandbox/components/helpers/getDefaultInitInfo.js
+++ b/src/app/viewSandbox/components/helpers/getDefaultInitInfo.js
@@ -26,6 +26,9 @@ export default ({ type, descriptor }) => {
     company: {
       orgId: 'ABCDEFGHIJKLMNOPQRSTUVWX@AdobeOrg'
     },
+    apiEndpoints: {
+      reactor: '//localhost'
+    },
     schema: descriptor?.schema || null
   };
 


### PR DESCRIPTION
## Description

API endpoints information will be provided by Lens to extension views.

## Related Issue

https://jira.corp.adobe.com/browse/PDCL-6367

## Motivation and Context

In the core extension for edge platform we need to fetch data from Launch API. We need to know the API endpoint we need to call based on the environment where Lens is running.

## How Has This Been Tested?

Manual.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
