### PR TITLE
Fixes for edge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.1.0.beta.0",
+  "version": "12.1.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-sandbox",
-      "version": "12.1.0.beta.0",
+      "version": "12.1.0-beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.1.0-beta.0",
+  "version": "12.1.0-beta.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-sandbox",
-      "version": "12.1.0-beta.0",
+      "version": "12.1.0-beta.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.14.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.0.0",
+  "version": "12.1.0.beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@adobe/reactor-sandbox",
-      "version": "12.0.0",
+      "version": "12.1.0.beta.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@adobe/react-spectrum": "^3.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.1.0-beta.0",
+  "version": "12.1.0-beta.1",
   "description": "Tasks for creating a sandbox for manually testing Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.0.0",
+  "version": "12.1.0.beta.0",
   "description": "Tasks for creating a sandbox for manually testing Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adobe/reactor-sandbox",
-  "version": "12.1.0.beta.0",
+  "version": "12.1.0-beta.0",
   "description": "Tasks for creating a sandbox for manually testing Launch extensions.",
   "author": {
     "name": "Adobe Systems",

--- a/src/tasks/helpers/extensionDescriptorPaths.js
+++ b/src/tasks/helpers/extensionDescriptorPaths.js
@@ -22,17 +22,17 @@ let extensionJsonPaths = glob.sync(
   `{node_modules/*/,node_modules/@*/*/,}${EXTENSION_DESCRIPTOR_FILENAME}`
 );
 
-// The sandbox might be in a different folder in one of the following cases:
-// - when it is linked (for developing purposes);
-// - when it is executed via npx;
-// - when it is globally installed. We want to search for the core extension in these cases too.
+// Searching for the edge core extension based on sandbox folder location:
+// - the extension is inside the sandbox node_modules folder when sandbox is linked
+// (for developing purposes) or installed globally;
+// - the extension in on the same level with the sandbox folder when sandbox is executed via npx.
 extensionJsonPaths = extensionJsonPaths.concat(
   glob
-    .sync(`{node_modules/*/,node_modules/@*/*/,}${EXTENSION_DESCRIPTOR_FILENAME}`, {
+    .sync(`{*/node_modules/*/,*/node_modules/@*/*/,*/,}${EXTENSION_DESCRIPTOR_FILENAME}`, {
       follow: true,
-      cwd: path.resolve(__dirname, '../../..')
+      cwd: path.resolve(__dirname, '../../../..')
     })
-    .map((p) => path.resolve(__dirname, '../../..', p))
+    .map((p) => path.resolve(__dirname, '../../../..', p))
 );
 
 const getExtensionPlatform = (filePath) => {

--- a/src/tasks/helpers/extensionDescriptorPaths.js
+++ b/src/tasks/helpers/extensionDescriptorPaths.js
@@ -14,24 +14,26 @@ const fs = require('fs-extra');
 const path = require('path');
 const glob = require('glob');
 const { EXTENSION_DESCRIPTOR_FILENAME } = require('../constants/files');
-const isSandboxLinked = require('../../helpers/isSandboxLinked');
 
-// We are searching for any extension folder that exists in `node_modules` (scoped or unscoped)
+// We are searching for any extension folder that exists in `node_modules` (scoped or unscoped).
+// This includes searching for extension in the folder
+// `./node_modules/@adobe/reactor-sandbox/node_modules`.
 let extensionJsonPaths = glob.sync(
   `{node_modules/*/,node_modules/@*/*/,}${EXTENSION_DESCRIPTOR_FILENAME}`
 );
 
-// When sandbox is linked, the core extensions will be accessible at a
-// different path than the ones from above. We could use one glob regex to find all the cases,
-// but it may be really slow if we use something like `node_modules/@*/**/*`.
-if (isSandboxLinked()) {
-  const b = 'node_modules/@adobe/reactor-sandbox';
-  extensionJsonPaths = extensionJsonPaths.concat(
-    glob.sync(`{${b}/node_modules/*/,${b}/node_modules/@*/*/}${EXTENSION_DESCRIPTOR_FILENAME}`, {
-      follow: true
+// The sandbox might be in a different folder in one of the following cases:
+// - when it is linked (for developing purposes);
+// - when it is executed via npx;
+// - when it is globally installed. We want to search for the core extension in these cases too.
+extensionJsonPaths = extensionJsonPaths.concat(
+  glob
+    .sync(`{node_modules/*/,node_modules/@*/*/,}${EXTENSION_DESCRIPTOR_FILENAME}`, {
+      follow: true,
+      cwd: path.resolve(__dirname, '../../..')
     })
-  );
-}
+    .map((p) => path.resolve(__dirname, '../../..', p))
+);
 
 const getExtensionPlatform = (filePath) => {
   const fileContents = JSON.parse(fs.readFileSync(path.resolve(filePath)));

--- a/src/tasks/helpers/generateEdgeLibrary.js
+++ b/src/tasks/helpers/generateEdgeLibrary.js
@@ -10,18 +10,19 @@ OF ANY KIND, either express or implied. See the License for the specific languag
 governing permissions and limitations under the License.
 */
 
+/* eslint-disable global-require */
+
 const fetch = require('node-fetch');
 const engine = require('@adobe/reactor-turbine-edge/src/index');
 
-const createEdgeExecute = require('./createEdgeExecute');
-const getEdgeContainer = require('./getEdgeContainer');
-
-let execute;
-
 module.exports = {
-  build: () => {
-    execute = createEdgeExecute(engine, getEdgeContainer(), { fetch });
-  },
+  getExecute: () => {
+    delete require.cache[require.resolve('./createEdgeExecute')];
+    delete require.cache[require.resolve('./getEdgeContainer')];
 
-  getExecute: () => execute
+    const createEdgeExecute = require('./createEdgeExecute');
+    const getEdgeContainer = require('./getEdgeContainer');
+
+    return createEdgeExecute(engine, getEdgeContainer(), { fetch });
+  }
 };

--- a/src/tasks/helpers/getEdgeContainer.js
+++ b/src/tasks/helpers/getEdgeContainer.js
@@ -106,6 +106,8 @@ const augmentModules = (modulesOutput, extensionDescriptor, extensionPath) => {
             .join(extensionPath, extensionDescriptor.libBasePath || '', featureDescriptor.libPath)
             .replace(/\\/g, '/');
 
+          delete require.cache[modulePath];
+
           const moduleMeta = {
             extensionName: extensionDescriptor.name
           };

--- a/src/tasks/helpers/saveContainer.js
+++ b/src/tasks/helpers/saveContainer.js
@@ -101,7 +101,7 @@ const deleteValueFromObject = (obj, propertyPath) => {
 };
 
 const functionTransform = (transformData, fnCode) => {
-  return `function(${transformData.parameters.join(', ')}) {${fnCode}}`;
+  return `function(${transformData.parameters.join(', ') || []}) {${fnCode}}`;
 };
 
 const generateFunctionTransformReplacements = (

--- a/src/tasks/run.js
+++ b/src/tasks/run.js
@@ -245,10 +245,6 @@ const configureApp = (app) => {
     try {
       saveContainer(req.body);
 
-      if (extensionDescriptor.platform === PLATFORMS.EDGE) {
-        generateEdgeLibrary.build();
-      }
-
       res.status(200);
       res.send('OK');
     } catch (error) {
@@ -275,8 +271,6 @@ const configureApp = (app) => {
   });
 
   if (extensionDescriptor.platform === PLATFORMS.EDGE) {
-    generateEdgeLibrary.build();
-
     app.post('/process-edge-request', (req, res) => {
       try {
         generateEdgeLibrary


### PR DESCRIPTION
## Description

- Generate the edge library for every hit sent ensuring this way you have the latest changes.
- Fix an error where the edge core extension was not found when the sandbox was executed via npx.
- Fixed an error where sandbox was losing container contents if you forgot to add parameters key to a transform.
## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The edge library was regenerated only when a change in the container was happening. This was making the library modules development a little harder. If you wanted to investigate a bug in a module, you were forced either to change the container or reload the sandbox. I changed the code so that the generation of the edge library happens for every hit send from the Library Sandbox section.

## How Has This Been Tested?

I tested that now core extension is found when the sandbox is run via npx or installed globally. I also tested that when sandbox is linked it also works as it should. I pushed a beta version on the next tag in order to test the changes.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
