### PR TITLE
PDCL-7836: support container.environment in the sandbox like producti…

### DIFF
--- a/src/app/constants.js
+++ b/src/app/constants.js
@@ -16,5 +16,6 @@ module.exports = {
     LIB_SANDBOX: '/libSandbox',
     VIEW_SANDBOX: '/viewSandbox',
     LIBRARY_EDITOR: '/libraryEditor'
-  }
+  },
+  LAUNCH_ENVIRONMENT_NAME: 'EN00000000000000000000000000000000'
 };

--- a/src/client/initFiles/container.js
+++ b/src/client/initFiles/container.js
@@ -68,9 +68,13 @@ module.exports = {
     }
   },
   buildInfo: {
-    turbineVersion: '14.0.0',
-    turbineBuildDate: '2016-07-01T18:10:34Z',
-    buildDate: '2016-08-01T12:10:33Z',
-    environment: 'development'
+    turbineVersion: '27.2.0',
+    turbineBuildDate: '2021-08-11T20:25:49Z',
+    buildDate: '2022-01-01T12:10:33Z',
+    environment: 'development' // deprecated, use environment block instead
+  },
+  environment: {
+    id: 'EN00000000000000000000000000000000',
+    stage: 'development'
   }
 };

--- a/src/helpers/validateSandboxVersion.js
+++ b/src/helpers/validateSandboxVersion.js
@@ -16,15 +16,17 @@ const sandboxPkg = require('../../package.json');
 const getSandboxLatestVersion = require('./getLatestVersion');
 
 module.exports = () => {
-  const sandboxOutdated = semverDiff(sandboxPkg.version, getSandboxLatestVersion());
+  const latestSandboxVersion = getSandboxLatestVersion();
+  const sandboxOutdated = semverDiff(sandboxPkg.version, latestSandboxVersion);
 
   if (sandboxOutdated) {
     // eslint-disable-next-line no-console
     console.log(
       chalk.red(
-        'Your sandbox is out of date. To ensure you are testing against the ' +
-          'latest code, please first update your sandbox by running ' +
-          `${chalk.cyan('npm i @adobe/reactor-sandbox@latest')}.`
+        `Your sandbox is out of date. You are using version "${sandboxPkg.version}", latest
+          version is "${latestSandboxVersion}". To ensure you are testing against the 
+          latest code, please first update your sandbox by running
+          "${chalk.cyan('npm i @adobe/reactor-sandbox@latest')}".`
       )
     );
   }

--- a/src/tasks/constants/files.js
+++ b/src/tasks/constants/files.js
@@ -11,6 +11,7 @@ governing permissions and limitations under the License.
 */
 
 const path = require('path');
+const { LAUNCH_ENVIRONMENT_NAME } = require('../../app/constants');
 
 const ENGINE_FILENAME = 'engine.js';
 const INIT_FILES_SRC_PATH = path.resolve(__dirname, '../../client/initFiles');
@@ -27,7 +28,7 @@ const files = {
   CONSUMER_PROVIDED_FILES_PATH: path.resolve('.sandbox'),
   CONTAINER_FILENAME: 'container.js',
   ENGINE_FILENAME: 'engine.js',
-  LAUNCH_LIBRARY_FILENAME: 'launch-EN00000000000000000000000000000000.js',
+  LAUNCH_LIBRARY_FILENAME: `launch-${LAUNCH_ENVIRONMENT_NAME}.js`,
   TURBINE_ENGINE_PATH: require.resolve(`@adobe/reactor-turbine/dist/${ENGINE_FILENAME}`),
   VIEW_SANDBOX_HTML_FILENAME: 'viewSandbox.html',
   LIB_SANDBOX_HTML_FILENAME: 'libSandbox.html',


### PR DESCRIPTION
…on turbine references.

<!-- Copyright 2019 Adobe. All rights reserved.
This file is licensed to you under the Apache License, Version 2.0 (the "License");
you may not use this file except in compliance with the License. You may obtain a copy
of the License at http://www.apache.org/licenses/LICENSE-2.0

Unless required by applicable law or agreed to in writing, software distributed under
the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
OF ANY KIND, either express or implied. See the License for the specific language
governing permissions and limitations under the License. -->

<!--- Provide a general summary of your changes in the Title above -->

## Description

A recent change to Turbine is expecting the `container.environment` to be its own standalone object instead of being inside `buildInfo`. This backsupports the old sandbox containers but also provides an environment object that Turbine can look at.

Closes #77 

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

https://jira.corp.adobe.com/browse/PDCL-7836

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
